### PR TITLE
Normalize the technician zombie

### DIFF
--- a/data/json/monsters/zed_misc.json
+++ b/data/json/monsters/zed_misc.json
@@ -1554,7 +1554,7 @@
     "id": "mon_zombie_technician",
     "type": "MONSTER",
     "name": { "str": "zombie technician" },
-    "description": "Still wearing its work clothes and hardhat, this zombie likely used to work on power lines or other electrical equipment.  As it approaches, everything metal you're carrying shifts very slightly in the zombie's direction, as if attracted by a strong magnetic force.",
+    "description": "Still wearing its work clothes and hardhat, this zombie likely used to work on power lines or other electrical equipment.",
     "default_faction": "zombie",
     "bodytype": "human",
     "species": [ "ZOMBIE", "HUMAN" ],
@@ -1581,15 +1581,15 @@
       { "name": "the face", "armor_mult": { "physical": 0 }, "coverage": 3 },
       { "name": "the eye", "armor_mult": { "physical": 0 }, "coverage": 1 }
     ],
-    "families": [ "prof_intro_biology", "prof_wp_zombie", "prof_electromagnetics" ],
+    "families": [ "prof_intro_biology", "prof_wp_zombie" ],
     "vision_day": 15,
     "vision_night": 2,
     "harvest": "zombie",
     "fungalize_into": "mon_zombie_fungus",
-    "special_attacks": [ [ "PULL_METAL_WEAPON", 25 ], { "type": "bite", "cooldown": 20 } ],
+    "special_attacks": [ { "type": "bite", "cooldown": 5 }, [ "GRAB", 7 ], [ "scratch", 20 ] ],
     "death_drops": "mon_zombie_technician_death_drops",
-    "upgrades": { "half_life": 35, "into_group": "GROUP_ZOMBIE_ELECTRIC_UPGRADE" },
-    "flags": [ "SEES", "HEARS", "WARM", "BASHES", "GROUP_BASH", "POISON", "NO_BREATHE", "REVIVES", "FILTHY", "RANGED_ATTACKER" ]
+    "upgrades": { "half_life": 30, "into_group": "GROUP_ZOMBIE_UPGRADE" },
+    "flags": [ "SEES", "HEARS", "WARM", "BASHES", "GROUP_BASH", "POISON", "NO_BREATHE", "REVIVES", "FILTHY" ]
   },
   {
     "id": "mon_zombie_miner",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "Remove zombie technician's pull ability and normalize its properties."
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

While in previous iterations it could have made sense for the technician to have some sort of powers, there aren't any excuses for it anymore - they don't have bionics and they're not "evolved" in some special way; the zombie technician is just a dead worker. That being the case, removing the zombie's special abilities makes it fit in with other zombies seems logical.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Replace the zombie technician's special attacks with those of regular zombies, removing the ranged pull attack. Change evolution group to that of normal zombies. Remove electromagnetics proficiency gain. Removed description detail that implies special ability.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Remove the technician zombie entirely: The technician zombie will now basically become a regular zombie with a different loot table, but I think keeping them helps the verisimilitude of the many locations they currently spawn in - there's lots of places where hard-hatted workers that might carry electricians' gear would be found, like power plants and all manner of industrial and scientific facilities.
Tone down the pull capability instead of remove it: Without the setting justifying some kind of cybernetics in the zombie technician, it seems inappropriate for them to have any special ability, particularly at their "base" evolution level. 
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Spawned some zombie technicians and held a metal item. They no longer tried to steal it.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
